### PR TITLE
記事詳細ページ切り替え機能

### DIFF
--- a/app/assets/stylesheets/article/show.scss
+++ b/app/assets/stylesheets/article/show.scss
@@ -298,7 +298,22 @@
             }
           }
         }
+      }
+    }
 
+    .page-change {
+      width: 100%;
+      display: flex;
+      justify-content: space-between;
+      margin-top: 20px;
+
+      .change-item-btn {
+        display: inline-block;
+        background: #fff;
+        color: #333;
+        padding: 8px;
+        box-shadow: 0 1px 3px rgba(0,0,0,0.4);
+        border-radius: 4px;
       }
     }
   }

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -11,4 +11,12 @@ class Article < ApplicationRecord
     validates :title
     validates :text
   end
+
+  def previous
+    Article.where('id < ?', id).order('id DESC').first
+  end
+
+  def next
+    Article.where('id > ?', id).order('id ASC').first
+  end
 end

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -86,7 +86,14 @@
           <% end %>
         </div>
       </div>
-
+      <div class="page-change">
+        <% if @article.previous.present? %>
+          <%= link_to '< prev', article_path(@article.previous), class: "change-item-btn" %>
+        <% end %>
+        <% if @article.next.present? %>
+          <%= link_to 'next >', article_path(@article.next), class: "change-item-btn" %>
+        <% end %>
+      </div>
     </div>
   </div>
 </main>

--- a/spec/system/articles_spec.rb
+++ b/spec/system/articles_spec.rb
@@ -316,3 +316,39 @@ RSpec.describe '記事検索', type: :system do
     expect(page).to have_content(@user.nickname)
   end
 end
+
+RSpec.describe '商品詳細ページ切り替え', type: :system do
+  before do
+    @user = FactoryBot.create(:user)
+    @user2 = FactoryBot.create(:user)
+    @article = FactoryBot.create(:article, user_id: @user.id)
+    @article2 = FactoryBot.create(:article, user_id: @user2.id)
+    @article3 = FactoryBot.create(:article, user_id: @user2.id)
+  end
+  it '記事詳細ページの下部の「next >」を選択すると一つ前の記事idの詳細ページに移動する' do
+    # トップページにいる
+    visit root_path
+    # @article2の記事詳細ページに移動する
+    visit article_path(@article2)
+    # @article2の記事詳細ページに「< prev」のリンクがある
+    expect(page).to have_link '< prev'
+    # 「< prev」をクリックすると、@articleの記事詳細ページにいることを確認する
+    click_on '< prev'
+    expect(current_path).to eq article_path(@article)
+    # article.idが最初の状態だと「< prev」のリンクが表示されないことを確認する
+    expect(page).to_not have_link '< prev'
+  end
+  it '記事詳細ページの下部の「< prev」を選択すると一つ後の記事idの詳細ページに移動する' do
+    # トップページにいる
+    visit root_path
+    # @article2の記事詳細ページに移動する
+    visit article_path(@article2)
+    # @article2の記事詳細ページに「next >」のリンクがある
+    expect(page).to have_link 'next >'
+    # 「next >」をクリックすると、@article3の記事詳細ページにいることを確認する
+    click_on 'next >'
+    expect(current_path).to eq article_path(@article3)
+    # article.idが最初の状態だと「next >」のリンクが表示されないことを確認する
+    expect(page).to_not have_link 'next >'
+  end
+end


### PR DESCRIPTION
# What
記事詳細ページ切り替え機能の実装

# Why
記事詳細ページ切り替え機能を実装することでユーザーのサイトの巡回をしやすくするため